### PR TITLE
feat(dashboard): Add dashboard layout and components

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  images: {
+    domains: ["res.cloudinary.com", "ui-avatars.com"],
+  },
   /* config options here */
 };
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
     "@radix-ui/react-toggle": "^1.1.2",
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@remixicon/react": "^4.6.0",
     "@tanstack/react-query": "^5.71.1",
     "@tanstack/react-query-devtools": "^5.71.1",
+    "@tanstack/react-table": "^8.21.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -53,6 +55,7 @@
     "react-hook-form": "^7.55.0",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.1",
+    "remixicon": "^4.6.0",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.1.0",
     "tw-animate-css": "^1.2.5",
@@ -70,5 +73,6 @@
     "eslint-config-next": "15.2.4",
     "tailwindcss": "^4",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/app/(auth)/sign-in/components/sign-in.form.tsx
+++ b/src/app/(auth)/sign-in/components/sign-in.form.tsx
@@ -16,8 +16,10 @@ import { useSignInMutation } from "@/hooks/queries/use-auth.query";
 import { signInSchema, type SignInInput } from "@/schema/sign-in.schema";
 import { AuthenticationError } from "@/server/services/auth.service";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export function SignInForm() {
+  const router = useRouter();
   const [formError, setFormError] = useState<string | null>(null);
   const form = useForm<SignInInput>({
     resolver: zodResolver(signInSchema),
@@ -37,6 +39,7 @@ export function SignInForm() {
     signIn(data, {
       onSuccess: (data) => {
         toast.success(`Bienvenue, ${data.user.name}`);
+        router.push(routes.app.dashboard);
       },
       onError: (error) => {
         if (error instanceof AuthenticationError) {

--- a/src/app/dashboard/components/app-sidebar.tsx
+++ b/src/app/dashboard/components/app-sidebar.tsx
@@ -1,0 +1,168 @@
+import * as React from "react";
+
+import { SearchForm } from "@/app/dashboard/components/search-form";
+import { TeamSwitcher } from "@/app/dashboard/components/team-switcher";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from "@/components/ui/sidebar";
+import {
+  RiScanLine,
+  RiBardLine,
+  RiUserFollowLine,
+  RiCodeSSlashLine,
+  RiLoginCircleLine,
+  RiLayoutLeftLine,
+  RiSettings3Line,
+  RiLeafLine,
+  RiLogoutBoxLine,
+} from "@remixicon/react";
+
+// This is sample data.
+const data = {
+  teams: [
+    {
+      name: "Esgis",
+      logo: "https://res.cloudinary.com/dlzlfasou/image/upload/v1741345507/logo-01_kp2j8x.png",
+    },
+    {
+      name: "Acme Corp.",
+      logo: "https://ui-avatars.com/api/?name=Acme+Corp&background=random",
+    },
+    {
+      name: "Esa",
+      logo: "https://ui-avatars.com/api/?name=Esa&background=random",
+    },
+  ],
+  navMain: [
+    {
+      title: "Sections",
+      url: "#",
+      items: [
+        {
+          title: "Dashboard",
+          url: "#",
+          icon: RiScanLine,
+        },
+        {
+          title: "Insights",
+          url: "#",
+          icon: RiBardLine,
+        },
+        {
+          title: "Contacts",
+          url: "#",
+          icon: RiUserFollowLine,
+          isActive: true,
+        },
+        {
+          title: "Tools",
+          url: "#",
+          icon: RiCodeSSlashLine,
+        },
+        {
+          title: "Integration",
+          url: "#",
+          icon: RiLoginCircleLine,
+        },
+        {
+          title: "Layouts",
+          url: "#",
+          icon: RiLayoutLeftLine,
+        },
+        {
+          title: "Reports",
+          url: "#",
+          icon: RiLeafLine,
+        },
+      ],
+    },
+    {
+      title: "Other",
+      url: "#",
+      items: [
+        {
+          title: "Settings",
+          url: "#",
+          icon: RiSettings3Line,
+        },
+        {
+          title: "Help Center",
+          url: "#",
+          icon: RiLeafLine,
+        },
+      ],
+    },
+  ],
+};
+
+export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar {...props}>
+      <SidebarHeader>
+        <TeamSwitcher teams={data.teams} />
+        <hr className="border-t border-border mx-2 -mt-px" />
+        <SearchForm className="mt-3" />
+      </SidebarHeader>
+      <SidebarContent>
+        {/* We create a SidebarGroup for each parent. */}
+        {data.navMain.map((item) => (
+          <SidebarGroup key={item.title}>
+            <SidebarGroupLabel className="uppercase text-muted-foreground/60">
+              {item.title}
+            </SidebarGroupLabel>
+            <SidebarGroupContent className="px-2">
+              <SidebarMenu>
+                {item.items.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton
+                      asChild
+                      className="group/menu-button font-medium gap-3 h-9 rounded-md bg-gradient-to-r hover:bg-transparent hover:from-sidebar-accent hover:to-sidebar-accent/40 data-[active=true]:from-primary/20 data-[active=true]:to-primary/5 [&>svg]:size-auto"
+                      isActive={item.isActive}
+                    >
+                      <a href={item.url}>
+                        {item.icon && (
+                          <item.icon
+                            className="text-muted-foreground/60 group-data-[active=true]/menu-button:text-primary"
+                            size={22}
+                            aria-hidden="true"
+                          />
+                        )}
+                        <span>{item.title}</span>
+                      </a>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
+      </SidebarContent>
+      <SidebarFooter>
+        <hr className="border-t border-border mx-2 -mt-px" />
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton className="font-medium gap-3 h-9 rounded-md bg-gradient-to-r hover:bg-transparent hover:from-sidebar-accent hover:to-sidebar-accent/40 data-[active=true]:from-primary/20 data-[active=true]:to-primary/5 [&>svg]:size-auto">
+              <RiLogoutBoxLine
+                className="text-muted-foreground/60 group-data-[active=true]/menu-button:text-primary"
+                size={22}
+                aria-hidden="true"
+              />
+              <span>Sign Out</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+      <SidebarRail />
+    </Sidebar>
+  );
+}

--- a/src/app/dashboard/components/banner.tsx
+++ b/src/app/dashboard/components/banner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { RiCloseLine } from "@remixicon/react";
+import { useState } from "react";
+
+export function Banner() {
+  const [isVisible, setIsVisible] = useState(true);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="ps-3 pe-1.5 py-1 rounded-md bg-foreground text-background fixed bottom-8 right-8 z-9999 shadow-lg">
+      <div className="flex items-center justify-between gap-0.5">
+        <a
+          href="https://crafted.is"
+          target="_blank"
+          className="block text-xs font-medium"
+        >
+          Made by Crafted
+        </a>
+        <button
+          className="group focus-visible:border-ring focus-visible:ring-ring/50 flex size-7 items-center justify-center rounded transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:pointer-events-none"
+          onClick={() => setIsVisible(false)}
+        >
+          <RiCloseLine
+            className="opacity-50 transition-opacity group-hover:opacity-80"
+            size={18}
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/components/contacts-table.tsx
+++ b/src/app/dashboard/components/contacts-table.tsx
@@ -1,0 +1,801 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import Image from "next/image";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Progress } from "@/components/ui/progress";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+} from "@/components/ui/pagination";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  FilterFn,
+  PaginationState,
+  SortingState,
+  VisibilityState,
+  flexRender,
+  getCoreRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  RiArrowDownSLine,
+  RiArrowUpSLine,
+  RiErrorWarningLine,
+  RiCloseCircleLine,
+  RiDeleteBinLine,
+  RiBardLine,
+  RiFilter3Line,
+  RiSearch2Line,
+  RiVerifiedBadgeFill,
+  RiCheckLine,
+  RiMoreLine,
+} from "@remixicon/react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+type Item = {
+  id: string;
+  image: string;
+  name: string;
+  status: string;
+  location: string;
+  verified: boolean;
+  referral: {
+    name: string;
+    image: string;
+  };
+  value: number;
+  joinDate: string;
+};
+
+const statusFilterFn: FilterFn<Item> = (
+  row,
+  columnId,
+  filterValue: string[]
+) => {
+  if (!filterValue?.length) return true;
+  const status = row.getValue(columnId) as string;
+  return filterValue.includes(status);
+};
+
+interface GetColumnsProps {
+  data: Item[];
+  setData: React.Dispatch<React.SetStateAction<Item[]>>;
+}
+
+const getColumns = ({ data, setData }: GetColumnsProps): ColumnDef<Item>[] => [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+    size: 28,
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    header: "Name",
+    accessorKey: "name",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3">
+        <Image
+          className="rounded-full"
+          src={row.original.image}
+          width={32}
+          height={32}
+          alt={row.getValue("name")}
+        />
+        <div className="font-medium">{row.getValue("name")}</div>
+      </div>
+    ),
+    size: 180,
+    enableHiding: false,
+  },
+  {
+    header: "ID",
+    accessorKey: "id",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">{row.getValue("id")}</span>
+    ),
+    size: 110,
+  },
+  {
+    header: "Status",
+    accessorKey: "status",
+    cell: ({ row }) => (
+      <div className="flex items-center h-full">
+        <Badge
+          variant="outline"
+          className={cn(
+            "gap-1 py-0.5 px-2 text-sm",
+            row.original.status === "Inactive"
+              ? "text-muted-foreground"
+              : "text-primary-foreground"
+          )}
+        >
+          {row.original.status === "Active" && (
+            <RiCheckLine
+              className="text-emerald-500"
+              size={14}
+              aria-hidden="true"
+            />
+          )}
+          {row.original.status === "Inactive" && "- "}
+          {row.original.status}
+        </Badge>
+      </div>
+    ),
+    size: 110,
+    filterFn: statusFilterFn,
+  },
+  {
+    header: "Location",
+    accessorKey: "location",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">{row.getValue("location")}</span>
+    ),
+    size: 140,
+  },
+  {
+    header: "Verified",
+    accessorKey: "verified",
+    cell: ({ row }) => (
+      <div>
+        <span className="sr-only">
+          {row.original.verified ? "Verified" : "Not Verified"}
+        </span>
+        <RiVerifiedBadgeFill
+          size={20}
+          className={cn(
+            row.original.verified
+              ? "fill-emerald-600"
+              : "fill-muted-foreground/50"
+          )}
+          aria-hidden="true"
+        />
+      </div>
+    ),
+    size: 90,
+  },
+  {
+    header: "Referral",
+    accessorKey: "referral",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3">
+        <Image
+          className="rounded-full"
+          src={row.original.referral.image}
+          width={20}
+          height={20}
+          alt={row.original.referral.name}
+        />
+        <div className="text-muted-foreground">
+          {row.original.referral.name}
+        </div>
+      </div>
+    ),
+    size: 140,
+  },
+  {
+    header: "Value",
+    accessorKey: "value",
+    cell: ({ row }) => {
+      const value = row.getValue("value") as number;
+      return (
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="flex h-full w-full items-center">
+                <Progress className="h-1 max-w-14" value={value} />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent align="start" sideOffset={-8}>
+              <p>{value}%</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    },
+    size: 80,
+  },
+  {
+    id: "actions",
+    header: () => <span className="sr-only">Actions</span>,
+    cell: ({ row }) => (
+      <RowActions setData={setData} data={data} item={row.original} />
+    ),
+    size: 60,
+    enableHiding: false,
+  },
+];
+
+export default function ContactsTable() {
+  const id = useId();
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [sorting, setSorting] = useState<SortingState>([
+    {
+      id: "name",
+      desc: false,
+    },
+  ]);
+
+  const [data, setData] = useState<Item[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const columns = useMemo(() => getColumns({ data, setData }), [data]);
+
+  useEffect(() => {
+    async function fetchPosts() {
+      try {
+        const res = await fetch(
+          "https://res.cloudinary.com/dlzlfasou/raw/upload/users-02_mohkpe.json"
+        );
+        const data = await res.json();
+        setData(data);
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchPosts();
+  }, []);
+
+  const handleDeleteRows = () => {
+    const selectedRows = table.getSelectedRowModel().rows;
+    const updatedData = data.filter(
+      (item) => !selectedRows.some((row) => row.original.id === item.id)
+    );
+    setData(updatedData);
+    table.resetRowSelection();
+  };
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    enableSortingRemoval: false,
+    getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: setPagination,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    getFilteredRowModel: getFilteredRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    state: {
+      sorting,
+      pagination,
+      columnFilters,
+      columnVisibility,
+    },
+  });
+
+  // Extract complex expressions into separate variables
+  const statusColumn = table.getColumn("status");
+  const statusFacetedValues = statusColumn?.getFacetedUniqueValues();
+  const statusFilterValue = statusColumn?.getFilterValue();
+
+  // Update useMemo hooks with simplified dependencies
+  const uniqueStatusValues = useMemo(() => {
+    if (!statusColumn) return [];
+    const values = Array.from(statusFacetedValues?.keys() ?? []);
+    return values.sort();
+  }, [statusColumn, statusFacetedValues]);
+
+  const statusCounts = useMemo(() => {
+    if (!statusColumn) return new Map();
+    return statusFacetedValues ?? new Map();
+  }, [statusColumn, statusFacetedValues]);
+
+  const selectedStatuses = useMemo(() => {
+    return (statusFilterValue as string[]) ?? [];
+  }, [statusFilterValue]);
+
+  const handleStatusChange = (checked: boolean, value: string) => {
+    const filterValue = table.getColumn("status")?.getFilterValue() as string[];
+    const newFilterValue = filterValue ? [...filterValue] : [];
+
+    if (checked) {
+      newFilterValue.push(value);
+    } else {
+      const index = newFilterValue.indexOf(value);
+      if (index > -1) {
+        newFilterValue.splice(index, 1);
+      }
+    }
+
+    table
+      .getColumn("status")
+      ?.setFilterValue(newFilterValue.length ? newFilterValue : undefined);
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Actions */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        {/* Left side */}
+        <div className="flex items-center gap-3">
+          {/* Filter by name */}
+          <div className="relative">
+            <Input
+              id={`${id}-input`}
+              ref={inputRef}
+              className={cn(
+                "peer min-w-60 ps-9 bg-background bg-gradient-to-br from-accent/60 to-accent",
+                Boolean(table.getColumn("name")?.getFilterValue()) && "pe-9"
+              )}
+              value={
+                (table.getColumn("name")?.getFilterValue() ?? "") as string
+              }
+              onChange={(e) =>
+                table.getColumn("name")?.setFilterValue(e.target.value)
+              }
+              placeholder="Search by name"
+              type="text"
+              aria-label="Search by name"
+            />
+            <div className="pointer-events-none absolute inset-y-0 start-0 flex items-center justify-center ps-2 text-muted-foreground/60 peer-disabled:opacity-50">
+              <RiSearch2Line size={20} aria-hidden="true" />
+            </div>
+            {Boolean(table.getColumn("name")?.getFilterValue()) && (
+              <button
+                className="absolute inset-y-0 end-0 flex h-full w-9 items-center justify-center rounded-e-lg text-muted-foreground/60 outline-offset-2 transition-colors hover:text-foreground focus:z-10 focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Clear filter"
+                onClick={() => {
+                  table.getColumn("name")?.setFilterValue("");
+                  if (inputRef.current) {
+                    inputRef.current.focus();
+                  }
+                }}
+              >
+                <RiCloseCircleLine size={16} aria-hidden="true" />
+              </button>
+            )}
+          </div>
+        </div>
+        {/* Right side */}
+        <div className="flex items-center gap-3">
+          {/* Delete button */}
+          {table.getSelectedRowModel().rows.length > 0 && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button className="ml-auto" variant="outline">
+                  <RiDeleteBinLine
+                    className="-ms-1 opacity-60"
+                    size={16}
+                    aria-hidden="true"
+                  />
+                  Delete
+                  <span className="-me-1 ms-1 inline-flex h-5 max-h-full items-center rounded border border-border bg-background px-1 font-[inherit] text-[0.625rem] font-medium text-muted-foreground/70">
+                    {table.getSelectedRowModel().rows.length}
+                  </span>
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <div className="flex flex-col gap-2 max-sm:items-center sm:flex-row sm:gap-4">
+                  <div
+                    className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border"
+                    aria-hidden="true"
+                  >
+                    <RiErrorWarningLine className="opacity-80" size={16} />
+                  </div>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      Are you absolutely sure?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This action cannot be undone. This will permanently delete{" "}
+                      {table.getSelectedRowModel().rows.length} selected{" "}
+                      {table.getSelectedRowModel().rows.length === 1
+                        ? "row"
+                        : "rows"}
+                      .
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                </div>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDeleteRows}>
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+          {/* Filter by status */}
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline">
+                <RiFilter3Line
+                  className="size-5 -ms-1.5 text-muted-foreground/60"
+                  size={20}
+                  aria-hidden="true"
+                />
+                Filter
+                {selectedStatuses.length > 0 && (
+                  <span className="-me-1 ms-3 inline-flex h-5 max-h-full items-center rounded border border-border bg-background px-1 font-[inherit] text-[0.625rem] font-medium text-muted-foreground/70">
+                    {selectedStatuses.length}
+                  </span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto min-w-36 p-3" align="end">
+              <div className="space-y-3">
+                <div className="text-xs font-medium uppercase text-muted-foreground/60">
+                  Status
+                </div>
+                <div className="space-y-3">
+                  {uniqueStatusValues.map((value, i) => (
+                    <div key={value} className="flex items-center gap-2">
+                      <Checkbox
+                        id={`${id}-${i}`}
+                        checked={selectedStatuses.includes(value)}
+                        onCheckedChange={(checked: boolean) =>
+                          handleStatusChange(checked, value)
+                        }
+                      />
+                      <Label
+                        htmlFor={`${id}-${i}`}
+                        className="flex grow justify-between gap-2 font-normal"
+                      >
+                        {value}{" "}
+                        <span className="ms-2 text-xs text-muted-foreground">
+                          {statusCounts.get(value)}
+                        </span>
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+          {/* New filter button */}
+          <Button variant="outline">
+            <RiBardLine
+              className="size-5 -ms-1.5 text-muted-foreground/60"
+              size={20}
+              aria-hidden="true"
+            />
+            New Filter
+          </Button>
+        </div>
+      </div>
+
+      {/* Table */}
+      <Table className="table-fixed border-separate border-spacing-0 [&_tr:not(:last-child)_td]:border-b">
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id} className="hover:bg-transparent">
+              {headerGroup.headers.map((header) => {
+                return (
+                  <TableHead
+                    key={header.id}
+                    style={{ width: `${header.getSize()}px` }}
+                    className="relative h-9 select-none bg-sidebar border-y border-border first:border-l first:rounded-l-lg last:border-r last:rounded-r-lg"
+                  >
+                    {header.isPlaceholder ? null : header.column.getCanSort() ? (
+                      <div
+                        className={cn(
+                          header.column.getCanSort() &&
+                            "flex h-full cursor-pointer select-none items-center gap-2"
+                        )}
+                        onClick={header.column.getToggleSortingHandler()}
+                        onKeyDown={(e) => {
+                          // Enhanced keyboard handling for sorting
+                          if (
+                            header.column.getCanSort() &&
+                            (e.key === "Enter" || e.key === " ")
+                          ) {
+                            e.preventDefault();
+                            header.column.getToggleSortingHandler()?.(e);
+                          }
+                        }}
+                        tabIndex={header.column.getCanSort() ? 0 : undefined}
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                        {{
+                          asc: (
+                            <RiArrowUpSLine
+                              className="shrink-0 opacity-60"
+                              size={16}
+                              aria-hidden="true"
+                            />
+                          ),
+                          desc: (
+                            <RiArrowDownSLine
+                              className="shrink-0 opacity-60"
+                              size={16}
+                              aria-hidden="true"
+                            />
+                          ),
+                        }[header.column.getIsSorted() as string] ?? null}
+                      </div>
+                    ) : (
+                      flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )
+                    )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <tbody aria-hidden="true" className="table-row h-1"></tbody>
+        <TableBody>
+          {isLoading ? (
+            <TableRow className="hover:bg-transparent [&:first-child>td:first-child]:rounded-tl-lg [&:first-child>td:last-child]:rounded-tr-lg [&:last-child>td:first-child]:rounded-bl-lg [&:last-child>td:last-child]:rounded-br-lg">
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                Loading...
+              </TableCell>
+            </TableRow>
+          ) : table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+                className="border-0 [&:first-child>td:first-child]:rounded-tl-lg [&:first-child>td:last-child]:rounded-tr-lg [&:last-child>td:first-child]:rounded-bl-lg [&:last-child>td:last-child]:rounded-br-lg h-px hover:bg-accent/50"
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} className="last:py-0 h-[inherit]">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow className="hover:bg-transparent [&:first-child>td:first-child]:rounded-tl-lg [&:first-child>td:last-child]:rounded-tr-lg [&:last-child>td:first-child]:rounded-bl-lg [&:last-child>td:last-child]:rounded-br-lg">
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+        <tbody aria-hidden="true" className="table-row h-1"></tbody>
+      </Table>
+
+      {/* Pagination */}
+      {table.getRowModel().rows.length > 0 && (
+        <div className="flex items-center justify-between gap-3">
+          <p
+            className="flex-1 whitespace-nowrap text-sm text-muted-foreground"
+            aria-live="polite"
+          >
+            Page{" "}
+            <span className="text-foreground">
+              {table.getState().pagination.pageIndex + 1}
+            </span>{" "}
+            of <span className="text-foreground">{table.getPageCount()}</span>
+          </p>
+          <Pagination className="w-auto">
+            <PaginationContent className="gap-3">
+              <PaginationItem>
+                <Button
+                  variant="outline"
+                  className="aria-disabled:pointer-events-none aria-disabled:opacity-50"
+                  onClick={() => table.previousPage()}
+                  disabled={!table.getCanPreviousPage()}
+                  aria-label="Go to previous page"
+                >
+                  Previous
+                </Button>
+              </PaginationItem>
+              <PaginationItem>
+                <Button
+                  variant="outline"
+                  className="aria-disabled:pointer-events-none aria-disabled:opacity-50"
+                  onClick={() => table.nextPage()}
+                  disabled={!table.getCanNextPage()}
+                  aria-label="Go to next page"
+                >
+                  Next
+                </Button>
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RowActions({
+  setData,
+  data,
+  item,
+}: {
+  setData: React.Dispatch<React.SetStateAction<Item[]>>;
+  data: Item[];
+  item: Item;
+}) {
+  const [isUpdatePending, startUpdateTransition] = useTransition();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  const handleStatusToggle = () => {
+    startUpdateTransition(() => {
+      const updatedData = data.map((dataItem) => {
+        if (dataItem.id === item.id) {
+          return {
+            ...dataItem,
+            status: item.status === "Active" ? "Inactive" : "Active",
+          };
+        }
+        return dataItem;
+      });
+      setData(updatedData);
+    });
+  };
+
+  const handleVerifiedToggle = () => {
+    startUpdateTransition(() => {
+      const updatedData = data.map((dataItem) => {
+        if (dataItem.id === item.id) {
+          return {
+            ...dataItem,
+            verified: !item.verified,
+          };
+        }
+        return dataItem;
+      });
+      setData(updatedData);
+    });
+  };
+
+  const handleDelete = () => {
+    startUpdateTransition(() => {
+      const updatedData = data.filter((dataItem) => dataItem.id !== item.id);
+      setData(updatedData);
+      setShowDeleteDialog(false);
+    });
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <div className="flex justify-end">
+            <Button
+              size="icon"
+              variant="ghost"
+              className="shadow-none text-muted-foreground/60"
+              aria-label="Edit item"
+            >
+              <RiMoreLine className="size-5" size={20} aria-hidden="true" />
+            </Button>
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-auto">
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              onClick={handleStatusToggle}
+              disabled={isUpdatePending}
+            >
+              {item.status === "Active"
+                ? "Deactivate contact"
+                : "Activate contact"}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={handleVerifiedToggle}
+              disabled={isUpdatePending}
+            >
+              {item.verified ? "Unverify contact" : "Verify contact"}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => setShowDeleteDialog(true)}
+            variant="destructive"
+            className="dark:data-[variant=destructive]:focus:bg-destructive/10"
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete this
+              contact.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isUpdatePending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isUpdatePending}
+              className="bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/app/dashboard/components/feedback-dialog.tsx
+++ b/src/app/dashboard/components/feedback-dialog.tsx
@@ -1,0 +1,52 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+
+export default function FeedbackDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="text-sm">
+          Feedback
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Send us feedback</DialogTitle>
+          <DialogDescription>
+            Watch{" "}
+            <a className="text-foreground hover:underline" href="#">
+              tutorials
+            </a>
+            , read Origin UI&lsquo;s{" "}
+            <a className="text-foreground hover:underline" href="#">
+              documentation
+            </a>
+            , or join our{" "}
+            <a className="text-foreground hover:underline" href="#">
+              Discord
+            </a>{" "}
+            for community help.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-5">
+          <Textarea
+            id="feedback"
+            placeholder="How can we improve Origin UI?"
+            aria-label="Send feedback"
+          />
+          <div className="flex flex-col sm:flex-row sm:justify-end">
+            <Button type="button">Send feedback</Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/dashboard/components/search-form.tsx
+++ b/src/app/dashboard/components/search-form.tsx
@@ -1,0 +1,28 @@
+import { useId } from "react";
+import { SidebarInput } from "@/components/ui/sidebar";
+import { SidebarGroup, SidebarGroupContent } from "@/components/ui/sidebar";
+import { RiSearch2Line } from "@remixicon/react";
+
+export function SearchForm({ ...props }: React.ComponentProps<"form">) {
+  const id = useId();
+
+  return (
+    <form {...props}>
+      <SidebarGroup className="py-0">
+        <SidebarGroupContent className="relative">
+          <div className="relative">
+            <SidebarInput id={id} className="ps-9 pe-9" aria-label="Search" />
+            <div className="pointer-events-none absolute inset-y-0 start-0 flex items-center justify-center ps-2 text-muted-foreground/60 peer-disabled:opacity-50">
+              <RiSearch2Line size={20} aria-hidden="true" />
+            </div>
+            <div className="pointer-events-none absolute inset-y-0 end-0 flex items-center justify-center pe-2 text-muted-foreground">
+              <kbd className="inline-flex size-5 max-h-full items-center justify-center rounded bg-input px-1 font-[inherit] text-[0.625rem] font-medium text-muted-foreground/70">
+                /
+              </kbd>
+            </div>
+          </div>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    </form>
+  );
+}

--- a/src/app/dashboard/components/stats-grid.tsx
+++ b/src/app/dashboard/components/stats-grid.tsx
@@ -1,0 +1,63 @@
+import { RiArrowRightUpLine } from "@remixicon/react";
+import { cn } from "@/lib/utils";
+
+interface StatsCardProps {
+  title: string;
+  value: string;
+  change: {
+    value: string;
+    trend: "up" | "down";
+  };
+  icon: React.ReactNode;
+}
+
+export function StatsCard({ title, value, change, icon }: StatsCardProps) {
+  const isPositive = change.trend === "up";
+  const trendColor = isPositive ? "text-emerald-500" : "text-red-500";
+
+  return (
+    <div className="relative p-4 lg:p-5 group before:absolute before:inset-y-8 before:right-0 before:w-px before:bg-gradient-to-b before:from-input/30 before:via-input before:to-input/30 last:before:hidden">
+      <div className="relative flex items-center gap-4">
+        <RiArrowRightUpLine
+          className="absolute right-0 top-0 opacity-0 group-has-[a:hover]:opacity-100 transition-opacity text-emerald-500"
+          size={20}
+          aria-hidden="true"
+        />
+        {/* Icon */}
+        <div className="max-[480px]:hidden size-10 shrink-0 rounded-full bg-emerald-600/25 border border-emerald-600/50 flex items-center justify-center text-emerald-500">
+          {icon}
+        </div>
+        {/* Content */}
+        <div>
+          <a
+            href="#"
+            className="font-medium tracking-widest text-xs uppercase text-muted-foreground/60 before:absolute before:inset-0"
+          >
+            {title}
+          </a>
+          <div className="text-2xl font-semibold mb-2">{value}</div>
+          <div className="text-xs text-muted-foreground/60">
+            <span className={cn("font-medium", trendColor)}>
+              {isPositive ? "↗" : "↘"} {change.value}
+            </span>{" "}
+            vs last week
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface StatsGridProps {
+  stats: StatsCardProps[];
+}
+
+export function StatsGrid({ stats }: StatsGridProps) {
+  return (
+    <div className="grid grid-cols-2 min-[1200px]:grid-cols-4 border border-border rounded-xl bg-gradient-to-br from-sidebar/60 to-sidebar">
+      {stats.map((stat) => (
+        <StatsCard key={stat.title} {...stat} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/dashboard/components/team-switcher.tsx
+++ b/src/app/dashboard/components/team-switcher.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+import { RiExpandUpDownLine, RiAddLine } from "@remixicon/react";
+
+export function TeamSwitcher({
+  teams,
+}: {
+  teams: {
+    name: string;
+    logo: string;
+  }[];
+}) {
+  const [activeTeam, setActiveTeam] = React.useState(teams[0] ?? null);
+
+  if (!teams.length) return null;
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground gap-3 [&>svg]:size-auto"
+            >
+              <div className="flex aspect-square size-8 items-center justify-center rounded-md overflow-hidden bg-sidebar-primary text-sidebar-primary-foreground">
+                {activeTeam && (
+                  <Image
+                    src={activeTeam.logo}
+                    width={36}
+                    height={36}
+                    alt={activeTeam.name}
+                  />
+                )}
+              </div>
+              <div className="grid flex-1 text-left text-base leading-tight">
+                <span className="truncate font-medium">
+                  {activeTeam?.name ?? "Select a Team"}
+                </span>
+              </div>
+              <RiExpandUpDownLine
+                className="ms-auto text-muted-foreground/60"
+                size={20}
+                aria-hidden="true"
+              />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-md"
+            align="start"
+            side="bottom"
+            sideOffset={4}
+          >
+            <DropdownMenuLabel className="uppercase text-muted-foreground/60 text-xs">
+              Teams
+            </DropdownMenuLabel>
+            {teams.map((team, index) => (
+              <DropdownMenuItem
+                key={team.name}
+                onClick={() => setActiveTeam(team)}
+                className="gap-2 p-2"
+              >
+                <div className="flex size-6 items-center justify-center rounded-md overflow-hidden">
+                  <Image
+                    src={team.logo}
+                    width={36}
+                    height={36}
+                    alt={team.name}
+                  />
+                </div>
+                {team.name}
+                <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="gap-2 p-2">
+              <RiAddLine className="opacity-60" size={16} aria-hidden="true" />
+              <div className="font-medium">Add team</div>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}

--- a/src/app/dashboard/components/user-dropdown.tsx
+++ b/src/app/dashboard/components/user-dropdown.tsx
@@ -1,0 +1,67 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import { RiSettingsLine, RiTeamLine, RiLogoutBoxLine } from "@remixicon/react";
+
+export default function UserDropdown() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-auto p-0 hover:bg-transparent">
+          <Avatar className="size-8">
+            <AvatarImage
+              src="https://res.cloudinary.com/dlzlfasou/image/upload/v1741345506/user_sam4wh.png"
+              width={32}
+              height={32}
+              alt="Profile image"
+            />
+            <AvatarFallback>KK</AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="max-w-64" align="end">
+        <DropdownMenuLabel className="flex min-w-0 flex-col">
+          <span className="truncate text-sm font-medium text-foreground">
+            Keith Kennedy
+          </span>
+          <span className="truncate text-xs font-normal text-muted-foreground">
+            k.kennedy@originui.com
+          </span>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem>
+            <RiSettingsLine
+              size={16}
+              className="opacity-60"
+              aria-hidden="true"
+            />
+            <span>Account settings</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            <RiTeamLine size={16} className="opacity-60" aria-hidden="true" />
+            <span>Affiliate area</span>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <RiLogoutBoxLine
+            size={16}
+            className="opacity-60"
+            aria-hidden="true"
+          />
+          <span>Sign out</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Experiment 01 - Crafted.is",
+};
+
+import { AppSidebar } from "@/app/dashboard/components/app-sidebar";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { Button } from "@/components/ui/button";
+import UserDropdown from "@/app/dashboard/components/user-dropdown";
+import FeedbackDialog from "@/app/dashboard/components/feedback-dialog";
+import ContactsTable from "@/app/dashboard/components/contacts-table";
+import { RiScanLine } from "@remixicon/react";
+import { StatsGrid } from "@/app/dashboard/components/stats-grid";
+import { ModeToggle } from "@/components/shared/theme/mode-toggle";
+
+export default function Page() {
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset className="overflow-hidden px-4 md:px-6 lg:px-8">
+        <header className="flex h-16 shrink-0 items-center gap-2 border-b">
+          <div className="flex flex-1 items-center gap-2 px-3">
+            <SidebarTrigger className="-ms-4" />
+            <Separator
+              orientation="vertical"
+              className="mr-2 data-[orientation=vertical]:h-4"
+            />
+            <Breadcrumb>
+              <BreadcrumbList>
+                <BreadcrumbItem className="hidden md:block">
+                  <BreadcrumbLink href="#">
+                    <RiScanLine size={22} aria-hidden="true" />
+                    <span className="sr-only">Dashboard</span>
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator className="hidden md:block" />
+                <BreadcrumbItem>
+                  <BreadcrumbPage>Contacts</BreadcrumbPage>
+                </BreadcrumbItem>
+              </BreadcrumbList>
+            </Breadcrumb>
+          </div>
+          <div className="flex gap-3 ml-auto">
+            <FeedbackDialog />
+            <ModeToggle />
+            <UserDropdown />
+          </div>
+        </header>
+        <div className="flex flex-1 flex-col gap-4 lg:gap-6 py-4 lg:py-6">
+          {/* Page intro */}
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <h1 className="text-2xl font-semibold">Oilà, Larry!</h1>
+              <p className="text-sm text-muted-foreground">
+                Here&rsquo;s an overview of your contacts. Manage or create new
+                ones with ease!
+              </p>
+            </div>
+            <Button className="px-3">Add Contact</Button>
+          </div>
+          {/* Numbers */}
+          <StatsGrid
+            stats={[
+              {
+                title: "Connections",
+                value: "427,296",
+                change: {
+                  value: "+12%",
+                  trend: "up",
+                },
+                icon: (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width={20}
+                    height={20}
+                    fill="currentColor"
+                  >
+                    <path d="M9 0v2.013a8.001 8.001 0 1 0 5.905 14.258l1.424 1.422A9.958 9.958 0 0 1 10 19.951c-5.523 0-10-4.478-10-10C0 4.765 3.947.5 9 0Zm10.95 10.95a9.954 9.954 0 0 1-2.207 5.329l-1.423-1.423a7.96 7.96 0 0 0 1.618-3.905h2.013ZM11.002 0c4.724.47 8.48 4.227 8.95 8.95h-2.013a8.004 8.004 0 0 0-6.937-6.937V0Z" />
+                  </svg>
+                ),
+              },
+              {
+                title: "Contacts",
+                value: "37,429",
+                change: {
+                  value: "+42%",
+                  trend: "up",
+                },
+                icon: (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width={18}
+                    height={19}
+                    fill="currentColor"
+                  >
+                    <path d="M2 9.5c0 .313.461.858 1.53 1.393C4.914 11.585 6.877 12 9 12c2.123 0 4.086-.415 5.47-1.107C15.538 10.358 16 9.813 16 9.5V7.329C14.35 8.349 11.827 9 9 9s-5.35-.652-7-1.671V9.5Zm14 2.829C14.35 13.349 11.827 14 9 14s-5.35-.652-7-1.671V14.5c0 .313.461.858 1.53 1.393C4.914 16.585 6.877 17 9 17c2.123 0 4.086-.415 5.47-1.107 1.069-.535 1.53-1.08 1.53-1.393v-2.171ZM0 14.5v-10C0 2.015 4.03 0 9 0s9 2.015 9 4.5v10c0 2.485-4.03 4.5-9 4.5s-9-2.015-9-4.5ZM9 7c2.123 0 4.086-.415 5.47-1.107C15.538 5.358 16 4.813 16 4.5c0-.313-.461-.858-1.53-1.393C13.085 2.415 11.123 2 9 2c-2.123 0-4.086.415-5.47 1.107C2.461 3.642 2 4.187 2 4.5c0 .313.461.858 1.53 1.393C4.914 6.585 6.877 7 9 7Z" />
+                  </svg>
+                ),
+              },
+              {
+                title: "Value",
+                value: "$82,439",
+                change: {
+                  value: "+37%",
+                  trend: "up",
+                },
+                icon: (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width={20}
+                    height={20}
+                    fill="currentColor"
+                  >
+                    <path d="M10 0c5.523 0 10 4.477 10 10s-4.477 10-10 10S0 15.523 0 10 4.477 0 10 0Zm0 2a8 8 0 1 0 0 16 8 8 0 0 0 0-16Zm3.833 3.337a.596.596 0 0 1 .763.067.59.59 0 0 1 .063.76c-2.18 3.046-3.38 4.678-3.598 4.897a1.5 1.5 0 0 1-2.122-2.122c.374-.373 2.005-1.574 4.894-3.602ZM15.5 9a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm-11 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2Zm2.318-3.596a1 1 0 1 1-1.414 1.414 1 1 0 0 1 1.414-1.414ZM10 3.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z" />
+                  </svg>
+                ),
+              },
+              {
+                title: "Referrals",
+                value: "3,497",
+                change: {
+                  value: "-17%",
+                  trend: "down",
+                },
+                icon: (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width={21}
+                    height={21}
+                    fill="currentColor"
+                  >
+                    <path d="m14.142.147 6.347 6.346a.5.5 0 0 1-.277.848l-1.474.23-5.656-5.657.212-1.485a.5.5 0 0 1 .848-.282ZM2.141 19.257c3.722-3.33 7.995-4.327 12.643-5.52l.446-4.017-4.297-4.298-4.018.447c-1.192 4.648-2.189 8.92-5.52 12.643L0 17.117c2.828-3.3 3.89-6.953 5.303-13.081l6.364-.708 5.657 5.657-.707 6.364c-6.128 1.415-9.782 2.475-13.081 5.304L2.14 19.258Zm5.284-6.029a2 2 0 1 1 2.828-2.828 2 2 0 0 1-2.828 2.828Z" />
+                  </svg>
+                ),
+              },
+            ]}
+          />
+          {/* Table */}
+          <div className="min-h-[100vh] flex-1 md:min-h-min">
+            <ContactsTable />
+          </div>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}


### PR DESCRIPTION
This commit introduces a new dashboard layout along with various components to enhance the user interface. Key changes include:

- Added a new `dashboard` page with a sidebar, header, and main content area.
- Implemented components such as `AppSidebar`, `ContactsTable`, `StatsGrid`, and `FeedbackDialog`.
- Integrated a banner for promotional messages and a user dropdown for account management.
- Enhanced the sign-in form to navigate to the dashboard upon successful authentication.
- Updated `next.config.ts` to allow images from specific domains and added new dependencies in `package.json` for UI components.